### PR TITLE
Fix unit/integration tests related with connection.connect and bolt-agent for Deno

### DIFF
--- a/packages/bolt-connection/test/connection-provider/authentication-provider.test.js
+++ b/packages/bolt-connection/test/connection-provider/authentication-provider.test.js
@@ -21,6 +21,7 @@ import AuthenticationProvider from '../../src/connection-provider/authentication
 
 describe('AuthenticationProvider', () => {
   const USER_AGENT = 'javascript-driver/5.5.0'
+  const BOLT_AGENT = 'javascript-driver/5.5.0 some information about system'
 
   describe('.authenticate()', () => {
     describe('when called without an auth', () => {
@@ -69,7 +70,7 @@ describe('AuthenticationProvider', () => {
 
             await authenticationProvider.authenticate({ connection })
 
-            expect(connection.connect).toHaveBeenCalledWith(USER_AGENT, authToken)
+            expect(connection.connect).toHaveBeenCalledWith(USER_AGENT, BOLT_AGENT, authToken, false)
           })
 
           it('should throw errors happened during token refresh', async () => {
@@ -201,7 +202,7 @@ describe('AuthenticationProvider', () => {
 
             await authenticationProvider.authenticate({ connection })
 
-            expect(connection.connect).toHaveBeenCalledWith(USER_AGENT, authToken)
+            expect(connection.connect).toHaveBeenCalledWith(USER_AGENT, BOLT_AGENT, authToken, false)
           })
 
           it('should throw errors happened during token refresh', async () => {
@@ -330,7 +331,7 @@ describe('AuthenticationProvider', () => {
 
             await authenticationProvider.authenticate({ connection })
 
-            expect(connection.connect).toHaveBeenCalledWith(USER_AGENT, authToken)
+            expect(connection.connect).toHaveBeenCalledWith(USER_AGENT, BOLT_AGENT, authToken, false)
           })
 
           it('should throw errors happened during connection.connect', async () => {
@@ -405,7 +406,7 @@ describe('AuthenticationProvider', () => {
 
           await authenticationProvider.authenticate({ connection, auth })
 
-          expect(connection.connect).toHaveBeenCalledWith(USER_AGENT, auth, false)
+          expect(connection.connect).toHaveBeenCalledWith(USER_AGENT, BOLT_AGENT, auth, false)
         })
 
         it('should return the connection', async () => {
@@ -451,7 +452,7 @@ describe('AuthenticationProvider', () => {
 
           await authenticationProvider.authenticate({ connection, auth })
 
-          expect(connection.connect).not.toHaveBeenCalledWith(USER_AGENT, auth)
+          expect(connection.connect).not.toHaveBeenCalledWith(USER_AGENT, BOLT_AGENT, auth)
         })
 
         it('should not call connection connect with the supplied auth and skipReAuth=true', async () => {
@@ -462,7 +463,7 @@ describe('AuthenticationProvider', () => {
 
           await authenticationProvider.authenticate({ connection, auth, skipReAuth: true })
 
-          expect(connection.connect).not.toHaveBeenCalledWith(USER_AGENT, auth)
+          expect(connection.connect).not.toHaveBeenCalledWith(USER_AGENT, BOLT_AGENT, auth)
         })
 
         if (supportsReAuth) {
@@ -474,7 +475,7 @@ describe('AuthenticationProvider', () => {
 
             await authenticationProvider.authenticate({ connection, auth, forceReAuth: true })
 
-            expect(connection.connect).toHaveBeenCalledWith(USER_AGENT, auth, false)
+            expect(connection.connect).toHaveBeenCalledWith(USER_AGENT, BOLT_AGENT, auth, false)
           })
         } else {
           it('should not call connection connect with the supplied auth if forceReAuth=true', async () => {
@@ -485,7 +486,7 @@ describe('AuthenticationProvider', () => {
 
             await authenticationProvider.authenticate({ connection, auth, forceReAuth: true })
 
-            expect(connection.connect).not.toHaveBeenCalledWith(USER_AGENT, auth)
+            expect(connection.connect).not.toHaveBeenCalledWith(USER_AGENT, BOLT_AGENT, auth)
           })
         }
 
@@ -519,7 +520,7 @@ describe('AuthenticationProvider', () => {
 
           await authenticationProvider.authenticate({ connection, auth })
 
-          expect(connection.connect).toHaveBeenCalledWith(USER_AGENT, auth, false)
+          expect(connection.connect).toHaveBeenCalledWith(USER_AGENT, BOLT_AGENT, auth, false)
         })
 
         it('should return the connection', async () => {
@@ -569,7 +570,7 @@ describe('AuthenticationProvider', () => {
 
           await authenticationProvider.authenticate({ connection, auth, waitReAuth })
 
-          expect(connection.connect).toHaveBeenCalledWith(USER_AGENT, auth, expectedWaitForReAuth)
+          expect(connection.connect).toHaveBeenCalledWith(USER_AGENT, BOLT_AGENT, auth, expectedWaitForReAuth)
         })
 
         it('should not call connect when skipReAuth=true', async () => {
@@ -593,7 +594,7 @@ describe('AuthenticationProvider', () => {
 
           await authenticationProvider.authenticate({ connection, auth })
 
-          expect(connection.connect).not.toHaveBeenCalledWith(USER_AGENT, auth)
+          expect(connection.connect).not.toHaveBeenCalledWith(USER_AGENT, BOLT_AGENT, auth)
         })
 
         it('should not call connection connect with the supplied auth and forceReAuth=true', async () => {
@@ -604,7 +605,7 @@ describe('AuthenticationProvider', () => {
 
           await authenticationProvider.authenticate({ connection, auth, forceReAuth: true })
 
-          expect(connection.connect).not.toHaveBeenCalledWith(USER_AGENT, auth)
+          expect(connection.connect).not.toHaveBeenCalledWith(USER_AGENT, BOLT_AGENT, auth)
         })
 
         it('should return the connection', async () => {
@@ -787,7 +788,8 @@ describe('AuthenticationProvider', () => {
     const authTokenManager = expirationBasedAuthTokenManager({ tokenProvider: authTokenProvider })
     const provider = new AuthenticationProvider({
       authTokenManager,
-      userAgent: USER_AGENT
+      userAgent: USER_AGENT,
+      boltAgent: BOLT_AGENT
     })
 
     if (mocks) {

--- a/packages/bolt-connection/test/connection/connection-channel.test.js
+++ b/packages/bolt-connection/test/connection/connection-channel.test.js
@@ -48,7 +48,7 @@ describe('ChannelConnection', () => {
         const protocolSupplier = () => protocol
         const connection = spyOnConnectionChannel({ channel, protocolSupplier })
 
-        await connection.connect('userAgent', {})
+        await connection.connect('userAgent', 'boltAgent', {})
 
         expect(channel.setupReceiveTimeout).toHaveBeenCalledWith(expected)
       }
@@ -79,7 +79,7 @@ describe('ChannelConnection', () => {
         const protocolSupplier = () => protocol
         const connection = spyOnConnectionChannel({ channel, protocolSupplier })
 
-        await connection.connect('userAgent', {})
+        await connection.connect('userAgent', 'boltAgent', {})
 
         expect(channel.setupReceiveTimeout).not.toHaveBeenCalled()
       }
@@ -114,7 +114,7 @@ describe('ChannelConnection', () => {
           address
         })
 
-        await connection.connect('userAgent', {})
+        await connection.connect('userAgent', 'boltAgent', {})
         expect(loggerFunction).toHaveBeenCalledWith(
           'info',
           `Connection [${
@@ -142,7 +142,7 @@ describe('ChannelConnection', () => {
         const protocolSupplier = () => protocol
         const connection = spyOnConnectionChannel({ channel, protocolSupplier, notificationFilter })
 
-        await connection.connect('userAgent', {})
+        await connection.connect('userAgent', 'boltAgent', {})
 
         const call = protocol.initialize.mock.calls[0][0]
 
@@ -159,7 +159,7 @@ describe('ChannelConnection', () => {
       const protocolSupplier = () => protocol
       const connection = spyOnConnectionChannel({ protocolSupplier })
 
-      await connection.connect('userAgent', authToken)
+      await connection.connect('userAgent', 'boltAgent', authToken)
 
       expect(connection.authToken).toEqual(authToken)
     })
@@ -181,7 +181,7 @@ describe('ChannelConnection', () => {
           const protocolSupplier = () => protocol
           const connection = spyOnConnectionChannel({ protocolSupplier })
 
-          await connection.connect('userAgent', authToken)
+          await connection.connect('userAgent', 'boltAgent', authToken)
 
           expect(protocol.initialize).not.toHaveBeenCalled()
           expect(protocol.logoff).toHaveBeenCalledWith()
@@ -207,7 +207,7 @@ describe('ChannelConnection', () => {
             const protocolSupplier = () => protocol
             const connection = spyOnConnectionChannel({ protocolSupplier })
 
-            const connectionPromise = connection.connect('userAgent', authToken, true)
+            const connectionPromise = connection.connect('userAgent', 'boltAgent', authToken, true)
 
             const isPending = await Promise.race([connectionPromise, Promise.resolve(true)])
             expect(isPending).toEqual(true)
@@ -243,7 +243,7 @@ describe('ChannelConnection', () => {
             const protocolSupplier = () => protocol
             const connection = spyOnConnectionChannel({ protocolSupplier })
 
-            const connectionPromise = connection.connect('userAgent', authToken, true)
+            const connectionPromise = connection.connect('userAgent', 'boltAgent', authToken, true)
 
             const isPending = await Promise.race([connectionPromise, Promise.resolve(true)])
             expect(isPending).toEqual(true)
@@ -278,7 +278,7 @@ describe('ChannelConnection', () => {
             const protocolSupplier = () => protocol
             const connection = spyOnConnectionChannel({ protocolSupplier })
 
-            const connectionPromise = connection.connect('userAgent', authToken, true)
+            const connectionPromise = connection.connect('userAgent', 'boltAgent', authToken, true)
 
             const isPending = await Promise.race([connectionPromise, Promise.resolve(true)])
             expect(isPending).toEqual(true)
@@ -314,7 +314,7 @@ describe('ChannelConnection', () => {
           const protocolSupplier = () => protocol
           const connection = spyOnConnectionChannel({ protocolSupplier })
 
-          await expect(connection.connect('userAgent', authToken)).rejects.toThrow(
+          await expect(connection.connect('userAgent', 'boltAgent', authToken)).rejects.toThrow(
             newError('Connection does not support re-auth')
           )
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,7 @@
     "test": "jest",
     "test::watch": "jest --watch",
     "test::unit": "npm run test",
-    "test::deno": "deno test --allow-sys ./test/deno/",
+    "test::deno": "deno test --allow-all ./test/deno/",
     "predocs": "npm run build && npm run build::es6",
     "docs": "esdoc -c esdoc.json",
     "prepare": "npm run build",

--- a/packages/core/src/internal/bolt-agent/deno/bolt-agent.ts
+++ b/packages/core/src/internal/bolt-agent/deno/bolt-agent.ts
@@ -26,7 +26,7 @@ export function fromVersion (version: string): string {
   //@ts-ignore
   const NODE_V8_VERSION = Deno.version.v8
   //@ts-ignore
-  const OS_NAME_VERSION = `${Deno.build.os} ${Deno.osRelease()}`
+  const OS_NAME_VERSION = `${Deno.build.os} ${Deno.osRelease ? Deno.osRelease() : ''}`.trim()
 
   return `neo4j-javascript/${version} (${OS_NAME_VERSION}; ${HOST_ARCH}) ${DENO_VERSION} (v8 ${NODE_V8_VERSION})`
 }

--- a/packages/core/test/deno/internal/bolt-agent/deno/bolt-agent.test.ts
+++ b/packages/core/test/deno/internal/bolt-agent/deno/bolt-agent.test.ts
@@ -38,7 +38,7 @@ Deno.test('Test full bolt agent', () => {
     //@ts-ignore
     const NODE_V8_VERSION = Deno.version.v8
     //@ts-ignore
-    const OS_NAME_VERSION = `${Deno.build.os} ${Deno.osRelease()}`
+    const OS_NAME_VERSION = `${Deno.build.os} ${Deno.osRelease ? Deno.osRelease() : ''}`.trim()
 
     const boltAgentExpected = `neo4j-javascript/5.3 (${OS_NAME_VERSION}; ${HOST_ARCH}) ${DENO_VERSION} (v8 ${NODE_V8_VERSION})`
 

--- a/packages/neo4j-driver-deno/lib/core/internal/bolt-agent/deno/bolt-agent.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/bolt-agent/deno/bolt-agent.ts
@@ -26,7 +26,7 @@ export function fromVersion (version: string): string {
   //@ts-ignore
   const NODE_V8_VERSION = Deno.version.v8
   //@ts-ignore
-  const OS_NAME_VERSION = `${Deno.build.os} ${Deno.osRelease()}`
+  const OS_NAME_VERSION = `${Deno.build.os} ${Deno.osRelease ? Deno.osRelease() : ''}`.trim()
 
   return `neo4j-javascript/${version} (${OS_NAME_VERSION}; ${HOST_ARCH}) ${DENO_VERSION} (v8 ${NODE_V8_VERSION})`
 }

--- a/packages/neo4j-driver/test/internal/connection-channel.test.js
+++ b/packages/neo4j-driver/test/internal/connection-channel.test.js
@@ -104,7 +104,7 @@ describe('#integration ChannelConnection', () => {
     }
 
     connection
-      .connect('mydriver/0.0.0', basicAuthToken())
+      .connect('mydriver/0.0.0', 'mydriver/0.0.0 some system info', basicAuthToken())
       .then(() => {
         connection
           .protocol()
@@ -177,7 +177,7 @@ describe('#integration ChannelConnection', () => {
     connection = await createConnection(`bolt://${sharedNeo4j.hostname}`)
 
     connection
-      .connect('mydriver/0.0.0', basicAuthToken())
+      .connect('mydriver/0.0.0', 'mydriver/0.0.0 some system info', basicAuthToken())
       .then(initializedConnection => {
         expect(initializedConnection).toBe(connection)
         done()
@@ -189,7 +189,7 @@ describe('#integration ChannelConnection', () => {
     connection = await createConnection(`bolt://${sharedNeo4j.hostname}`) // wrong port
 
     connection
-      .connect('mydriver/0.0.0', basicWrongAuthToken())
+      .connect('mydriver/0.0.0', 'mydriver/0.0.0 some system info', basicWrongAuthToken())
       .then(() => done.fail('Should not initialize'))
       .catch(error => {
         expect(error).toBeDefined()
@@ -200,7 +200,7 @@ describe('#integration ChannelConnection', () => {
   it('should have server version after connection initialization completed', async done => {
     connection = await createConnection(`bolt://${sharedNeo4j.hostname}`)
     connection
-      .connect('mydriver/0.0.0', basicAuthToken())
+      .connect('mydriver/0.0.0', 'mydriver/0.0.0 some system info', basicAuthToken())
       .then(initializedConnection => {
         expect(initializedConnection).toBe(connection)
         const serverVersion = ServerVersion.fromString(connection.version)
@@ -214,7 +214,7 @@ describe('#integration ChannelConnection', () => {
     connection = await createConnection(`bolt://${sharedNeo4j.hostname}`)
 
     connection
-      .connect('mydriver/0.0.0', basicWrongAuthToken())
+      .connect('mydriver/0.0.0', 'mydriver/0.0.0 some system info', basicWrongAuthToken())
       .then(() => done.fail('Should not connect'))
       .catch(initialError => {
         expect(initialError).toBeDefined()
@@ -274,7 +274,7 @@ describe('#integration ChannelConnection', () => {
     connection = await createConnection(`bolt://${sharedNeo4j.hostname}`)
 
     connection
-      .connect('my-driver/1.2.3', basicAuthToken())
+      .connect('my-driver/1.2.3', 'mydriver/0.0.0 some system info', basicAuthToken())
       .then(() => {
         connection
           .resetAndFlush()
@@ -297,7 +297,7 @@ describe('#integration ChannelConnection', () => {
   it('should fail to reset and flush when FAILURE received', async done => {
     createConnection(`bolt://${sharedNeo4j.hostname}`)
       .then(connection => {
-        connection.connect('my-driver/1.2.3', basicAuthToken()).then(() => {
+        connection.connect('my-driver/1.2.3', 'mydriver/0.0.0 some system info', basicAuthToken()).then(() => {
           connection
             .resetAndFlush()
             .then(() => done.fail('Should fail'))
@@ -325,7 +325,7 @@ describe('#integration ChannelConnection', () => {
     connection = await createConnection(`bolt://${sharedNeo4j.hostname}`)
 
     connection
-      .connect('my-driver/1.2.3', basicAuthToken())
+      .connect('my-driver/1.2.3', 'mydriver/0.0.0 some system info', basicAuthToken())
       .then(() => {
         connection
           .resetAndFlush()
@@ -353,7 +353,7 @@ describe('#integration ChannelConnection', () => {
     createConnection(`bolt://${sharedNeo4j.hostname}`)
       .then(connection => {
         connection
-          .connect('my-driver/1.2.3', basicAuthToken())
+          .connect('my-driver/1.2.3', 'mydriver/0.0.0 some system info', basicAuthToken())
           .then(() => {
             connection.protocol()._responseHandler._currentFailure = newError(
               'Hello'
@@ -419,7 +419,7 @@ describe('#integration ChannelConnection', () => {
     connection = await createConnection(`bolt://${sharedNeo4j.hostname}`)
     recordWrittenMessages(connection._protocol, messages)
 
-    await connection.connect('mydriver/0.0.0', basicAuthToken())
+    await connection.connect('mydriver/0.0.0', 'mydriver/0.0.0 some system info', basicAuthToken())
 
     expect(connection.isOpen()).toBeTruthy()
     await connection.close()
@@ -436,7 +436,7 @@ describe('#integration ChannelConnection', () => {
   it('should not prepare broken connection to close', async () => {
     connection = await createConnection(`bolt://${sharedNeo4j.hostname}`)
 
-    await connection.connect('my-connection/9.9.9', basicAuthToken())
+    await connection.connect('my-connection/9.9.9', 'mydriver/0.0.0 some system info', basicAuthToken())
     expect(connection._protocol).toBeDefined()
     expect(connection._protocol).not.toBeNull()
 

--- a/packages/neo4j-driver/test/internal/connection-delegate.test.js
+++ b/packages/neo4j-driver/test/internal/connection-delegate.test.js
@@ -128,7 +128,7 @@ describe('#unit DelegateConnection', () => {
     const spy = spyOn(delegate, 'connect')
     const connection = new DelegateConnection(delegate, null)
 
-    connection.connect('neo4j/js-driver', {})
+    connection.connect('neo4j/js-driver', 'mydriver/0.0.0 some system info', {})
 
     expect(spy).toHaveBeenCalledTimes(1)
   })


### PR DESCRIPTION
The test code related with `connection.connect` were calling the method without the bolt agent causing all kind of errors. Add the bolt agent  to the calls and expectations solves the issue.

`Deno.osRelease()` and the flag `--allow-sys` are not available in Deno 1.19.2. The missing flag was causing the test don't even start. The method un-existence was causing the code fails because is calling a non existing method.

The missing flag is solved by using `--allow-all` instead. This is a more permissive flag, but it is not a big deal in test env.

The absence of `Deno.osRelease()` is solved by not setting the release when this method is not available. This might be an issue for old Deno users, but it's not a blocker.
