### PR TITLE
Revert changes in the `userAgent`

### DIFF
--- a/packages/bolt-connection/src/bolt/bolt-protocol-v1.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v1.js
@@ -184,7 +184,7 @@ export default class BoltProtocol {
     // passing notification filter on this protocol version throws an error
     assertNotificationFilterIsEmpty(notificationFilter, this._onProtocolError, observer)
 
-    this.write(RequestMessage.init(userAgent === '' || userAgent == null ? boltAgent : userAgent, authToken), observer, true)
+    this.write(RequestMessage.init(userAgent, authToken), observer, true)
 
     return observer
   }

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v3.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v3.js
@@ -78,7 +78,7 @@ export default class BoltProtocol extends BoltProtocolV2 {
     // passing notification filter on this protocol version throws an error
     assertNotificationFilterIsEmpty(notificationFilter, this._onProtocolError, observer)
 
-    this.write(RequestMessage.hello(userAgent === '' || userAgent == null ? boltAgent : userAgent, authToken), observer, true)
+    this.write(RequestMessage.hello(userAgent, authToken), observer, true)
 
     return observer
   }

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v4x1.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v4x1.js
@@ -83,7 +83,7 @@ export default class BoltProtocol extends BoltProtocolV4 {
     assertNotificationFilterIsEmpty(notificationFilter, this._onProtocolError, observer)
 
     this.write(
-      RequestMessage.hello(userAgent === '' || userAgent == null ? boltAgent : userAgent, authToken, this._serversideRouting),
+      RequestMessage.hello(userAgent, authToken, this._serversideRouting),
       observer,
       true
     )

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v4x3.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v4x3.js
@@ -104,7 +104,7 @@ export default class BoltProtocol extends BoltProtocolV42 {
     assertNotificationFilterIsEmpty(notificationFilter, this._onProtocolError, observer)
 
     this.write(
-      RequestMessage.hello(userAgent === '' || userAgent == null ? boltAgent : userAgent, authToken, this._serversideRouting, ['utc']),
+      RequestMessage.hello(userAgent, authToken, this._serversideRouting, ['utc']),
       observer,
       true
     )

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v5x0.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v5x0.js
@@ -63,7 +63,7 @@ export default class BoltProtocol extends BoltProtocolV44 {
     assertNotificationFilterIsEmpty(notificationFilter, this._onProtocolError, observer)
 
     this.write(
-      RequestMessage.hello(userAgent === '' || userAgent == null ? boltAgent : userAgent, authToken, this._serversideRouting),
+      RequestMessage.hello(userAgent, authToken, this._serversideRouting),
       observer,
       true
     )

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v5x1.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v5x1.js
@@ -71,7 +71,7 @@ export default class BoltProtocol extends BoltProtocolV5x0 {
     assertNotificationFilterIsEmpty(notificationFilter, this._onProtocolError, observer)
 
     this.write(
-      RequestMessage.hello5x1(userAgent === '' || userAgent == null ? boltAgent : userAgent, this._serversideRouting),
+      RequestMessage.hello5x1(userAgent, this._serversideRouting),
       observer,
       false
     )

--- a/packages/bolt-connection/src/bolt/bolt-protocol-v5x2.js
+++ b/packages/bolt-connection/src/bolt/bolt-protocol-v5x2.js
@@ -69,7 +69,7 @@ export default class BoltProtocol extends BoltProtocolV5x1 {
 
     this.write(
       // if useragent is null then for all versions before 5.3 it should be bolt agent by default
-      RequestMessage.hello5x2(userAgent === '' || userAgent == null ? boltAgent : userAgent, notificationFilter, this._serversideRouting),
+      RequestMessage.hello5x2(userAgent, notificationFilter, this._serversideRouting),
       observer,
       false
     )

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v1.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v1.test.js
@@ -104,6 +104,29 @@ describe('#unit BoltProtocolV1', () => {
     expect(protocol.flushes).toEqual([true])
   })
 
+  it.each([
+    'javascript-driver/5.5.0',
+    '',
+    undefined,
+    null
+  ])('should always use the user agent set by the user', (userAgent) => {
+    const recorder = new utils.MessageRecordingConnection()
+    const protocol = new BoltProtocolV1(recorder, null, false)
+    utils.spyProtocolWrite(protocol)
+
+    const clientName = 'js-driver/1.2.3'
+    const authToken = { username: 'neo4j', password: 'secret' }
+
+    const observer = protocol.initialize({ userAgent, boltAgent: clientName, authToken })
+
+    protocol.verifyMessageCount(1)
+    expect(protocol.messages[0]).toBeMessage(
+      RequestMessage.init(userAgent, authToken)
+    )
+    expect(protocol.observers).toEqual([observer])
+    expect(protocol.flushes).toEqual([true])
+  })
+
   it('should run a query', () => {
     const recorder = new utils.MessageRecordingConnection()
     const protocol = utils.spyProtocolWrite(

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v2.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v2.test.js
@@ -18,6 +18,7 @@
  */
 
 import BoltProtocolV2 from '../../src/bolt/bolt-protocol-v2'
+import RequestMessage from '../../src/bolt/request-message'
 import utils from '../test-utils'
 
 import {
@@ -42,6 +43,29 @@ import { notificationFilterBehaviour } from './behaviour'
 describe('#unit BoltProtocolV2', () => {
   beforeEach(() => {
     expect.extend(utils.matchers)
+  })
+
+  it.each([
+    'javascript-driver/5.5.0',
+    '',
+    undefined,
+    null
+  ])('should always use the user agent set by the user', (userAgent) => {
+    const recorder = new utils.MessageRecordingConnection()
+    const protocol = new BoltProtocolV2(recorder, null, false)
+    utils.spyProtocolWrite(protocol)
+
+    const clientName = 'js-driver/1.2.3'
+    const authToken = { username: 'neo4j', password: 'secret' }
+
+    const observer = protocol.initialize({ userAgent, boltAgent: clientName, authToken })
+
+    protocol.verifyMessageCount(1)
+    expect(protocol.messages[0]).toBeMessage(
+      RequestMessage.init(userAgent, authToken)
+    )
+    expect(protocol.observers).toEqual([observer])
+    expect(protocol.flushes).toEqual([true])
   })
 
   it('should return correct bolt version number', () => {

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v3.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v3.test.js
@@ -89,6 +89,29 @@ describe('#unit BoltProtocolV3', () => {
     expect(protocol.flushes).toEqual([true])
   })
 
+  it.each([
+    'javascript-driver/5.5.0',
+    '',
+    undefined,
+    null
+  ])('should always use the user agent set by the user', (userAgent) => {
+    const recorder = new utils.MessageRecordingConnection()
+    const protocol = new BoltProtocolV3(recorder, null, false)
+    utils.spyProtocolWrite(protocol)
+
+    const clientName = 'js-driver/1.2.3'
+    const authToken = { username: 'neo4j', password: 'secret' }
+
+    const observer = protocol.initialize({ userAgent, boltAgent: clientName, authToken })
+
+    protocol.verifyMessageCount(1)
+    expect(protocol.messages[0]).toBeMessage(
+      RequestMessage.hello(userAgent, authToken)
+    )
+    expect(protocol.observers).toEqual([observer])
+    expect(protocol.flushes).toEqual([true])
+  })
+
   it('should run a query', () => {
     const bookmarks = new Bookmarks([
       'neo4j:bookmark:v1:tx1',

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v4x0.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v4x0.test.js
@@ -57,6 +57,29 @@ describe('#unit BoltProtocolV4x0', () => {
     expect.extend(utils.matchers)
   })
 
+  it.each([
+    'javascript-driver/5.5.0',
+    '',
+    undefined,
+    null
+  ])('should always use the user agent set by the user', (userAgent) => {
+    const recorder = new utils.MessageRecordingConnection()
+    const protocol = new BoltProtocolV4x0(recorder, null, false)
+    utils.spyProtocolWrite(protocol)
+
+    const clientName = 'js-driver/1.2.3'
+    const authToken = { username: 'neo4j', password: 'secret' }
+
+    const observer = protocol.initialize({ userAgent, boltAgent: clientName, authToken })
+
+    protocol.verifyMessageCount(1)
+    expect(protocol.messages[0]).toBeMessage(
+      RequestMessage.hello(userAgent, authToken)
+    )
+    expect(protocol.observers).toEqual([observer])
+    expect(protocol.flushes).toEqual([true])
+  })
+
   it('should run a query', () => {
     const database = 'testdb'
     const bookmarks = new Bookmarks([

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v4x1.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v4x1.test.js
@@ -18,6 +18,7 @@
  */
 
 import BoltProtocolV4x1 from '../../src/bolt/bolt-protocol-v4x1'
+import RequestMessage from '../../src/bolt/request-message'
 import utils from '../test-utils'
 import {
   Date,
@@ -45,6 +46,33 @@ const {
 } = internal
 
 describe('#unit BoltProtocolV4x1', () => {
+  beforeEach(() => {
+    expect.extend(utils.matchers)
+  })
+
+  it.each([
+    'javascript-driver/5.5.0',
+    '',
+    undefined,
+    null
+  ])('should always use the user agent set by the user', (userAgent) => {
+    const recorder = new utils.MessageRecordingConnection()
+    const protocol = new BoltProtocolV4x1(recorder, null, false)
+    utils.spyProtocolWrite(protocol)
+
+    const clientName = 'js-driver/1.2.3'
+    const authToken = { username: 'neo4j', password: 'secret' }
+
+    const observer = protocol.initialize({ userAgent, boltAgent: clientName, authToken })
+
+    protocol.verifyMessageCount(1)
+    expect(protocol.messages[0]).toBeMessage(
+      RequestMessage.hello(userAgent, authToken)
+    )
+    expect(protocol.observers).toEqual([observer])
+    expect(protocol.flushes).toEqual([true])
+  })
+
   describe('Bolt v4.4', () => {
     /**
      * @param {string} impersonatedUser The impersonated user.

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v4x2.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v4x2.test.js
@@ -18,6 +18,7 @@
  */
 
 import BoltProtocolV4x2 from '../../src/bolt/bolt-protocol-v4x2'
+import RequestMessage from '../../src/bolt/request-message'
 import utils from '../test-utils'
 import {
   Date,
@@ -45,6 +46,33 @@ const {
 } = internal
 
 describe('#unit BoltProtocolV4x2', () => {
+  beforeEach(() => {
+    expect.extend(utils.matchers)
+  })
+
+  it.each([
+    'javascript-driver/5.5.0',
+    '',
+    undefined,
+    null
+  ])('should always use the user agent set by the user', (userAgent) => {
+    const recorder = new utils.MessageRecordingConnection()
+    const protocol = new BoltProtocolV4x2(recorder, null, false)
+    utils.spyProtocolWrite(protocol)
+
+    const clientName = 'js-driver/1.2.3'
+    const authToken = { username: 'neo4j', password: 'secret' }
+
+    const observer = protocol.initialize({ userAgent, boltAgent: clientName, authToken })
+
+    protocol.verifyMessageCount(1)
+    expect(protocol.messages[0]).toBeMessage(
+      RequestMessage.hello(userAgent, authToken)
+    )
+    expect(protocol.observers).toEqual([observer])
+    expect(protocol.flushes).toEqual([true])
+  })
+
   describe('Bolt v4.4', () => {
     /**
      * @param {string} impersonatedUser The impersonated user.

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v4x3.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v4x3.test.js
@@ -206,6 +206,29 @@ describe('#unit BoltProtocolV4x3', () => {
     expect(protocol.flushes).toEqual([true])
   })
 
+  it.each([
+    'javascript-driver/5.5.0',
+    '',
+    undefined,
+    null
+  ])('should always use the user agent set by the user', (userAgent) => {
+    const recorder = new utils.MessageRecordingConnection()
+    const protocol = new BoltProtocolV4x3(recorder, null, false)
+    utils.spyProtocolWrite(protocol)
+
+    const clientName = 'js-driver/1.2.3'
+    const authToken = { username: 'neo4j', password: 'secret' }
+
+    const observer = protocol.initialize({ userAgent, boltAgent: clientName, authToken })
+
+    protocol.verifyMessageCount(1)
+    expect(protocol.messages[0]).toBeMessage(
+      RequestMessage.hello(userAgent, authToken, null, ['utc'])
+    )
+    expect(protocol.observers).toEqual([observer])
+    expect(protocol.flushes).toEqual([true])
+  })
+
   it('should begin a transaction', () => {
     const bookmarks = new Bookmarks([
       'neo4j:bookmark:v1:tx1',

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v4x4.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v4x4.test.js
@@ -280,6 +280,29 @@ describe('#unit BoltProtocolV4x4', () => {
     expect(protocol.flushes).toEqual([true])
   })
 
+  it.each([
+    'javascript-driver/5.5.0',
+    '',
+    undefined,
+    null
+  ])('should always use the user agent set by the user', (userAgent) => {
+    const recorder = new utils.MessageRecordingConnection()
+    const protocol = new BoltProtocolV4x4(recorder, null, false)
+    utils.spyProtocolWrite(protocol)
+
+    const clientName = 'js-driver/1.2.3'
+    const authToken = { username: 'neo4j', password: 'secret' }
+
+    const observer = protocol.initialize({ userAgent, boltAgent: clientName, authToken })
+
+    protocol.verifyMessageCount(1)
+    expect(protocol.messages[0]).toBeMessage(
+      RequestMessage.hello(userAgent, authToken, null, ['utc'])
+    )
+    expect(protocol.observers).toEqual([observer])
+    expect(protocol.flushes).toEqual([true])
+  })
+
   it('should begin a transaction', () => {
     const bookmarks = new Bookmarks([
       'neo4j:bookmark:v1:tx1',

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v5x0.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v5x0.test.js
@@ -280,6 +280,29 @@ describe('#unit BoltProtocolV5x0', () => {
     expect(protocol.flushes).toEqual([true])
   })
 
+  it.each([
+    'javascript-driver/5.5.0',
+    '',
+    undefined,
+    null
+  ])('should always use the user agent set by the user', (userAgent) => {
+    const recorder = new utils.MessageRecordingConnection()
+    const protocol = new BoltProtocolV5x0(recorder, null, false)
+    utils.spyProtocolWrite(protocol)
+
+    const clientName = 'js-driver/1.2.3'
+    const authToken = { username: 'neo4j', password: 'secret' }
+
+    const observer = protocol.initialize({ userAgent, boltAgent: clientName, authToken })
+
+    protocol.verifyMessageCount(1)
+    expect(protocol.messages[0]).toBeMessage(
+      RequestMessage.hello(userAgent, authToken)
+    )
+    expect(protocol.observers).toEqual([observer])
+    expect(protocol.flushes).toEqual([true])
+  })
+
   it('should begin a transaction', () => {
     const bookmarks = new Bookmarks([
       'neo4j:bookmark:v1:tx1',

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v5x2.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v5x2.test.js
@@ -295,7 +295,12 @@ describe('#unit BoltProtocolV5x2', () => {
     expect(protocol.flushes).toEqual([false, true])
   })
 
-  it('should set userAgent to bolt agent when userAgent is null', () => {
+  it.each([
+    'javascript-driver/5.5.0',
+    '',
+    undefined,
+    null
+  ])('should always use the user agent set by the user', (userAgent) => {
     const recorder = new utils.MessageRecordingConnection()
     const protocol = new BoltProtocolV5x2(recorder, null, false)
     utils.spyProtocolWrite(protocol)
@@ -303,11 +308,11 @@ describe('#unit BoltProtocolV5x2', () => {
     const clientName = 'js-driver/1.2.3'
     const authToken = { username: 'neo4j', password: 'secret' }
 
-    const observer = protocol.initialize({ userAgent: null, boltAgent: clientName, authToken })
+    const observer = protocol.initialize({ userAgent, boltAgent: clientName, authToken })
 
     protocol.verifyMessageCount(2)
     expect(protocol.messages[0]).toBeMessage(
-      RequestMessage.hello5x1(clientName)
+      RequestMessage.hello5x1(userAgent)
     )
     expect(protocol.messages[1]).toBeMessage(
       RequestMessage.logon(authToken)

--- a/packages/bolt-connection/test/bolt/bolt-protocol-v5x3.test.js
+++ b/packages/bolt-connection/test/bolt/bolt-protocol-v5x3.test.js
@@ -296,6 +296,44 @@ describe('#unit BoltProtocolV5x3', () => {
     expect(protocol.flushes).toEqual([false, true])
   })
 
+  it.each([
+    'javascript-driver/5.5.0',
+    '',
+    undefined,
+    null
+  ])('should always use the user agent set by the user', (userAgent) => {
+    const recorder = new utils.MessageRecordingConnection()
+    const protocol = new BoltProtocolV5x3(recorder, null, false)
+    utils.spyProtocolWrite(protocol)
+
+    const clientName = 'js-driver/1.2.3'
+    const authToken = { username: 'neo4j', password: 'secret' }
+
+    const observer = protocol.initialize({ userAgent, boltAgent: clientName, authToken })
+
+    protocol.verifyMessageCount(2)
+    expect(protocol.messages[0]).toBeMessage(
+      RequestMessage.hello5x3(userAgent, clientName)
+    )
+    expect(protocol.messages[1]).toBeMessage(
+      RequestMessage.logon(authToken)
+    )
+
+    expect(protocol.observers.length).toBe(2)
+
+    // hello observer
+    const helloObserver = protocol.observers[0]
+    expect(helloObserver).toBeInstanceOf(LoginObserver)
+    expect(helloObserver).not.toBe(observer)
+
+    // login observer
+    const loginObserver = protocol.observers[1]
+    expect(loginObserver).toBeInstanceOf(LoginObserver)
+    expect(loginObserver).toBe(observer)
+
+    expect(protocol.flushes).toEqual([false, true])
+  })
+
   it.each(
     [true, false]
   )('should logon to the server [flush=%s]', (flush) => {

--- a/packages/neo4j-driver-deno/README.md
+++ b/packages/neo4j-driver-deno/README.md
@@ -48,8 +48,11 @@ await session.close();
 await driver.close();
 ```
 
-You can use `deno run --allow-net ...` or `deno repl` to run this example. If
-you don't have a running Neo4j instance, you can use
+You can use `deno run --allow-net --allow-sys...` or `deno repl` to run this example. 
+
+For Deno versions bellow `1.27.1`, you should use the flag `--allow-env` instead of `--allow-sys`.
+
+If you don't have a running Neo4j instance, you can use
 `docker run --rm -p 7687:7687 -e NEO4J_AUTH=neo4j/driverdemo neo4j:4.4` to
 quickly spin one up.
 

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v1.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v1.js
@@ -184,7 +184,7 @@ export default class BoltProtocol {
     // passing notification filter on this protocol version throws an error
     assertNotificationFilterIsEmpty(notificationFilter, this._onProtocolError, observer)
 
-    this.write(RequestMessage.init(userAgent === '' || userAgent == null ? boltAgent : userAgent, authToken), observer, true)
+    this.write(RequestMessage.init(userAgent, authToken), observer, true)
 
     return observer
   }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v3.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v3.js
@@ -78,7 +78,7 @@ export default class BoltProtocol extends BoltProtocolV2 {
     // passing notification filter on this protocol version throws an error
     assertNotificationFilterIsEmpty(notificationFilter, this._onProtocolError, observer)
 
-    this.write(RequestMessage.hello(userAgent === '' || userAgent == null ? boltAgent : userAgent, authToken), observer, true)
+    this.write(RequestMessage.hello(userAgent, authToken), observer, true)
 
     return observer
   }

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v4x1.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v4x1.js
@@ -83,7 +83,7 @@ export default class BoltProtocol extends BoltProtocolV4 {
     assertNotificationFilterIsEmpty(notificationFilter, this._onProtocolError, observer)
 
     this.write(
-      RequestMessage.hello(userAgent === '' || userAgent == null ? boltAgent : userAgent, authToken, this._serversideRouting),
+      RequestMessage.hello(userAgent, authToken, this._serversideRouting),
       observer,
       true
     )

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v4x3.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v4x3.js
@@ -104,7 +104,7 @@ export default class BoltProtocol extends BoltProtocolV42 {
     assertNotificationFilterIsEmpty(notificationFilter, this._onProtocolError, observer)
 
     this.write(
-      RequestMessage.hello(userAgent === '' || userAgent == null ? boltAgent : userAgent, authToken, this._serversideRouting, ['utc']),
+      RequestMessage.hello(userAgent, authToken, this._serversideRouting, ['utc']),
       observer,
       true
     )

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x0.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x0.js
@@ -63,7 +63,7 @@ export default class BoltProtocol extends BoltProtocolV44 {
     assertNotificationFilterIsEmpty(notificationFilter, this._onProtocolError, observer)
 
     this.write(
-      RequestMessage.hello(userAgent === '' || userAgent == null ? boltAgent : userAgent, authToken, this._serversideRouting),
+      RequestMessage.hello(userAgent, authToken, this._serversideRouting),
       observer,
       true
     )

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x1.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x1.js
@@ -71,7 +71,7 @@ export default class BoltProtocol extends BoltProtocolV5x0 {
     assertNotificationFilterIsEmpty(notificationFilter, this._onProtocolError, observer)
 
     this.write(
-      RequestMessage.hello5x1(userAgent === '' || userAgent == null ? boltAgent : userAgent, this._serversideRouting),
+      RequestMessage.hello5x1(userAgent, this._serversideRouting),
       observer,
       false
     )

--- a/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x2.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/bolt/bolt-protocol-v5x2.js
@@ -69,7 +69,7 @@ export default class BoltProtocol extends BoltProtocolV5x1 {
 
     this.write(
       // if useragent is null then for all versions before 5.3 it should be bolt agent by default
-      RequestMessage.hello5x2(userAgent === '' || userAgent == null ? boltAgent : userAgent, notificationFilter, this._serversideRouting),
+      RequestMessage.hello5x2(userAgent, notificationFilter, this._serversideRouting),
       observer,
       false
     )

--- a/packages/neo4j-driver-deno/lib/mod.ts
+++ b/packages/neo4j-driver-deno/lib/mod.ts
@@ -118,6 +118,8 @@ const {
   urlUtil
 } = internal
 
+const USER_AGENT = 'neo4j-javascript/' + VERSION
+
 function isAuthTokenManager (value: unknown): value is AuthTokenManager {
   if (typeof value === 'object' &&
     value != null &&
@@ -333,6 +335,7 @@ function driver (
   const authTokenManager = createAuthManager(authToken)
 
   // Use default user agent or user agent specified by user.
+  config.userAgent = config.userAgent ?? USER_AGENT
   config.boltAgent = internal.boltAgent.fromVersion('neo4j-javascript/' + VERSION)
   const address = ServerAddress.fromUrl(parsedUrl.hostAndPort)
 

--- a/packages/neo4j-driver-lite/src/index.ts
+++ b/packages/neo4j-driver-lite/src/index.ts
@@ -117,6 +117,8 @@ const {
   urlUtil
 } = internal
 
+const USER_AGENT = 'neo4j-javascript/' + VERSION
+
 function isAuthTokenManager (value: unknown): value is AuthTokenManager {
   if (typeof value === 'object' &&
     value != null &&
@@ -332,6 +334,7 @@ function driver (
   const authTokenManager = createAuthManager(authToken)
 
   // Use default user agent or user agent specified by user.
+  config.userAgent = config.userAgent ?? USER_AGENT
   config.boltAgent = internal.boltAgent.fromVersion('neo4j-javascript/' + VERSION)
   const address = ServerAddress.fromUrl(parsedUrl.hostAndPort)
 

--- a/packages/neo4j-driver/src/index.js
+++ b/packages/neo4j-driver/src/index.js
@@ -93,6 +93,8 @@ const {
   urlUtil
 } = internal
 
+const USER_AGENT = 'neo4j-javascript/' + VERSION
+
 function isAuthTokenManager (value) {
   return typeof value === 'object' &&
     value != null &&
@@ -298,6 +300,8 @@ function driver (url, authToken, config = {}) {
 
   const authTokenManager = createAuthManager(authToken)
 
+  // Use default user agent or user agent specified by user.
+  config.userAgent = config.userAgent || USER_AGENT
   config.boltAgent = internal.boltAgent.fromVersion('neo4j-javascript/' + VERSION)
   const address = ServerAddress.fromUrl(parsedUrl.hostAndPort)
 


### PR DESCRIPTION
This property should not change the behaviour for backwards compatibility. The `userAgent` appears on the logs and it might be parsed by reporters.