### PR TITLE
Fix browser tests in the lite driver

### DIFF
--- a/packages/core/src/internal/bolt-agent/node/bolt-agent.ts
+++ b/packages/core/src/internal/bolt-agent/node/bolt-agent.ts
@@ -23,7 +23,7 @@ interface SystemInfo {
   hostArch: string
   nodeVersion: string
   v8Version: string
-  platform: NodeJS.Platform
+  platform: string
   release: string
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -72,6 +72,9 @@ export interface Config {
   logging?: LoggingConfig
   resolver?: (address: string) => string[] | Promise<string[]>
   userAgent?: string
+}
+
+export interface InternalConfig extends Config {
   boltAgent?: BoltAgent
 }
 

--- a/packages/neo4j-driver-deno/lib/core/internal/bolt-agent/node/bolt-agent.ts
+++ b/packages/neo4j-driver-deno/lib/core/internal/bolt-agent/node/bolt-agent.ts
@@ -23,7 +23,7 @@ interface SystemInfo {
   hostArch: string
   nodeVersion: string
   v8Version: string
-  platform: NodeJS.Platform
+  platform: string
   release: string
 }
 

--- a/packages/neo4j-driver-deno/lib/core/types.ts
+++ b/packages/neo4j-driver-deno/lib/core/types.ts
@@ -72,6 +72,9 @@ export interface Config {
   logging?: LoggingConfig
   resolver?: (address: string) => string[] | Promise<string[]>
   userAgent?: string
+}
+
+export interface InternalConfig extends Config {
   boltAgent?: BoltAgent
 }
 

--- a/packages/neo4j-driver-lite/src/index.ts
+++ b/packages/neo4j-driver-lite/src/index.ts
@@ -103,6 +103,7 @@ import { DirectConnectionProvider, RoutingConnectionProvider } from 'neo4j-drive
 
 type AuthToken = coreTypes.AuthToken
 type Config = coreTypes.Config
+type InternalConfig = coreTypes.InternalConfig
 type TrustStrategy = coreTypes.TrustStrategy
 type EncryptionLevel = coreTypes.EncryptionLevel
 type SessionMode = coreTypes.SessionMode
@@ -287,6 +288,9 @@ function driver (
   assertString(url, 'Bolt URL')
   const parsedUrl = urlUtil.parseDatabaseUrl(url)
 
+  // enabling set boltAgent
+  const _config = config as unknown as InternalConfig
+
   // Determine entryption/trust options from the URL.
   let routing = false
   let encrypted = false
@@ -322,20 +326,21 @@ function driver (
   // Encryption enabled on URL, propagate trust to the config.
   if (encrypted) {
     // Check for configuration conflict between URL and config.
-    if ('encrypted' in config || 'trust' in config) {
+    if ('encrypted' in _config || 'trust' in _config) {
       throw new Error(
         'Encryption/trust can only be configured either through URL or config, not both'
       )
     }
-    config.encrypted = ENCRYPTION_ON
-    config.trust = trust
+    _config.encrypted = ENCRYPTION_ON
+    _config.trust = trust
   }
 
   const authTokenManager = createAuthManager(authToken)
 
   // Use default user agent or user agent specified by user.
-  config.userAgent = config.userAgent ?? USER_AGENT
-  config.boltAgent = internal.boltAgent.fromVersion('neo4j-javascript/' + VERSION)
+  _config.userAgent = _config.userAgent ?? USER_AGENT
+  _config.boltAgent = internal.boltAgent.fromVersion('neo4j-javascript/' + VERSION)
+
   const address = ServerAddress.fromUrl(parsedUrl.hostAndPort)
 
   const meta = {
@@ -344,13 +349,13 @@ function driver (
     routing
   }
 
-  return new Driver(meta, config, createConnectionProviderFunction())
+  return new Driver(meta, _config, createConnectionProviderFunction())
 
   function createConnectionProviderFunction (): (id: number, config: Config, log: Logger, hostNameResolver: ConfiguredCustomResolver) => ConnectionProvider {
     if (routing) {
       return (
         id: number,
-        config: Config,
+        config: InternalConfig,
         log: Logger,
         hostNameResolver: ConfiguredCustomResolver
       ): ConnectionProvider =>
@@ -372,7 +377,7 @@ function driver (
         )
       }
 
-      return (id: number, config: Config, log: Logger): ConnectionProvider =>
+      return (id: number, config: InternalConfig, log: Logger): ConnectionProvider =>
         new DirectConnectionProvider({
           id,
           config,

--- a/packages/neo4j-driver-lite/test/integration/browser.environment.js
+++ b/packages/neo4j-driver-lite/test/integration/browser.environment.js
@@ -23,6 +23,11 @@ class BrowserEnvironment extends NodeEnvironment {
   async setup () {
     await super.setup()
     this.global.WebSocket = WebSocket
+    this.global.window = {
+      navigator: {
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36'
+      }
+    }
   }
 
   async teardown () {


### PR DESCRIPTION
The basic browser tests in the lite driver is done by using a WebSocket implementation in a mocked browser. So, mocking the `window` is needed.