### PR TITLE
Fix browser test in Node10 environment

### DIFF
--- a/packages/bolt-connection/src/channel/browser/browser-channel.js
+++ b/packages/bolt-connection/src/channel/browser/browser-channel.js
@@ -166,10 +166,10 @@ export default class WebSocketChannel {
    */
   close () {
     return new Promise((resolve, reject) => {
+      this._clearConnectionTimeout()
       if (this._ws && this._ws.readyState !== WS_CLOSED) {
         this._open = false
         this.stopReceiveTimeout()
-        this._clearConnectionTimeout()
         this._ws.onclose = () => resolve()
         this._ws.close()
       } else {

--- a/packages/neo4j-driver-deno/lib/bolt-connection/channel/browser/browser-channel.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/channel/browser/browser-channel.js
@@ -166,10 +166,10 @@ export default class WebSocketChannel {
    */
   close () {
     return new Promise((resolve, reject) => {
+      this._clearConnectionTimeout()
       if (this._ws && this._ws.readyState !== WS_CLOSED) {
         this._open = false
         this.stopReceiveTimeout()
-        this._clearConnectionTimeout()
         this._ws.onclose = () => resolve()
         this._ws.close()
       } else {

--- a/packages/neo4j-driver-lite/test/integration/browser.environment.js
+++ b/packages/neo4j-driver-lite/test/integration/browser.environment.js
@@ -23,10 +23,9 @@ class BrowserEnvironment extends NodeEnvironment {
   async setup () {
     await super.setup()
     this.global.WebSocket = WebSocket
-    this.global.window = {
-      navigator: {
-        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36'
-      }
+    this.global.window = globalThis
+    this.global.window.navigator = {
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36'
     }
   }
 


### PR DESCRIPTION
The window mock was broken because it miss `Symbol`, `Date` and other global definitions. Set the window as `globalThis` and then define the navigator in it solves the issue.

A proper way of solving the issue will be use `jsdom`, however this plugin doesn't work in Node10.

Also fixed an issue with timers getting hanging in some situations. The issue was catched by browser test with `--detectOpenHandles`.

<!--
    Thanks for making the effort to create a Pull Request!
    Please read the comment in its entirety fist.
    If you haven't already, please sign our Contributor License Agreement at
    https://neo4j.com/developer/cla/
    Commits from accounts that have not signed the CLA will fail the CI and
    will not be reviewed. If you are a first-time contributor and have just
    signed the CLA, please include a note about this in the PR comment as some
    manual steps from our side are required.
-->

<!--
    Title:
    PRs targeting the current default branch (nightly driver) don't follow a
    fixed naming scheme.
    If your PR is a backport, please link the original PR in the comments.
-->

<!--
    Description:
    Please include a summary of the changes in this PR and their purpose.
    Link any related issues or PRs.
-->
