### PR TITLE
Make it compliant with testkit

### DIFF
--- a/packages/bolt-connection/src/connection-provider/home-db-cache/home-db-cache.js
+++ b/packages/bolt-connection/src/connection-provider/home-db-cache/home-db-cache.js
@@ -17,13 +17,19 @@
  * limitations under the License.
  */
 
+const DEFAULT_KEY = -1
+
 export default class HomeDBCache {
   constructor ({ maxHomeDatabaseDelay }) {
+    this._disabled = maxHomeDatabaseDelay === 0
     this._maxHomeDatabaseDelay = maxHomeDatabaseDelay || 5000
     this._cache = new Map()
   }
 
   set ({ impersonatedUser, auth, databaseName }) {
+    if (this._disabled) {
+      return null
+    }
     if (databaseName == null) {
       return null
     }
@@ -32,7 +38,7 @@ export default class HomeDBCache {
       let key = impersonatedUser || auth
 
       if (key == null) {
-        key = 'null' // This is for when auth is turned off basically
+        key = DEFAULT_KEY // This is for when auth is turned off basically
       }
 
       this._cache.set(key, { databaseName: databaseName, insertTime: Date.now() })
@@ -40,9 +46,12 @@ export default class HomeDBCache {
   }
 
   get ({ impersonatedUser, auth }) {
+    if (this._disabled) {
+      return null
+    }
     let key = impersonatedUser || auth
     if (key == null) {
-      key = 'null' // This is for when auth is turned off basically
+      key = DEFAULT_KEY // This is for when auth is turned off basically
     }
 
     const dbAndCreatedTime = this._cache.get(key)

--- a/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/home-db-cache/home-db-cache.js
+++ b/packages/neo4j-driver-deno/lib/bolt-connection/connection-provider/home-db-cache/home-db-cache.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const DEFAULT_KEY = -1
+
+export default class HomeDBCache {
+  constructor ({ maxHomeDatabaseDelay }) {
+    this._disabled = maxHomeDatabaseDelay === 0
+    this._maxHomeDatabaseDelay = maxHomeDatabaseDelay || 5000
+    this._cache = new Map()
+  }
+
+  set ({ impersonatedUser, auth, databaseName }) {
+    if (this._disabled) {
+      return null
+    }
+    if (databaseName == null) {
+      return null
+    }
+
+    if (this._maxHomeDatabaseDelay > 0) {
+      let key = impersonatedUser || auth
+
+      if (key == null) {
+        key = DEFAULT_KEY // This is for when auth is turned off basically
+      }
+
+      this._cache.set(key, { databaseName: databaseName, insertTime: Date.now() })
+    }
+  }
+
+  get ({ impersonatedUser, auth }) {
+    if (this._disabled) {
+      return null
+    }
+    let key = impersonatedUser || auth
+    if (key == null) {
+      key = DEFAULT_KEY // This is for when auth is turned off basically
+    }
+
+    const dbAndCreatedTime = this._cache.get(key)
+
+    if (dbAndCreatedTime == null) {
+      return null
+    }
+
+    if (Date.now() > dbAndCreatedTime.insertTime + this._maxHomeDatabaseDelay) {
+      this._cache.delete(key)
+      return null
+    } else {
+      return this._cache.get(key).databaseName
+    }
+  }
+
+  clearCache () {
+    this._cache = new Map()
+  }
+}

--- a/packages/testkit-backend/src/feature/common.js
+++ b/packages/testkit-backend/src/feature/common.js
@@ -29,6 +29,7 @@ const features = [
   'Feature:API:Driver.VerifyAuthentication',
   'Feature:API:Driver.VerifyConnectivity',
   'Feature:API:Session:NotificationsConfig',
+  'Feature:HomeDbCache',
   'Optimization:AuthPipelining',
   'Optimization:EagerTransactionBegin',
   'Optimization:ImplicitDefaultArguments',

--- a/packages/testkit-backend/src/request-handlers-rx.js
+++ b/packages/testkit-backend/src/request-handlers-rx.js
@@ -33,7 +33,8 @@ export {
   ExpirationBasedAuthTokenProviderCompleted,
   FakeTimeInstall,
   FakeTimeTick,
-  FakeTimeUninstall
+  FakeTimeUninstall,
+  ForceHomeDatabaseResolution
 } from './request-handlers.js'
 
 export function NewSession ({ neo4j }, context, data, wire) {

--- a/packages/testkit-backend/src/request-handlers.js
+++ b/packages/testkit-backend/src/request-handlers.js
@@ -78,6 +78,9 @@ export function NewDriver ({ neo4j }, context, data, wire) {
       disabledCategories: data.notificationsDisabledCategories
     }
   }
+  if ('maxHomeDatabaseDelayMs' in data) {
+    config.maxHomeDatabaseDelay = data.maxHomeDatabaseDelayMs
+  }
   let driver
   try {
     driver = neo4j.driver(uri, parsedAuthToken, config)
@@ -597,6 +600,17 @@ export function GetRoutingTable (_, context, { driverId, database }, wire) {
     wire.writeResponse(responses.RoutingTable({ routingTable }))
   } else {
     wire.writeError('Driver does not support routing')
+  }
+}
+
+export function ForceHomeDatabaseResolution (_, context, { driverId }, wire) {
+  const driver = context.getDriver(driverId)
+
+  if (driver) {
+    driver.forceHomeDbResolution()
+    wire.writeResponse(responses.Driver({ id: driverId }))
+  } else {
+    wire.writeError('Driver not found!')
   }
 }
 


### PR DESCRIPTION
For making it compliant, the driver needs to: 

* Implement `ForceHomeDatabaseResolution` message on TK
* Implement `maxHomeDatabaseDelayMs` param in `NewDriver` message on TK.
* Use the cache in `verifyAuthentication` and `verifyConnectivity`
* Keep the same database name for the entire session lifetime. This means the `onDatabaseNameResolved` should be called to signalise the session about the database name even if the resolution was taken from the cache. Otherwise, the session can pick connection to other database if the cache expires or the `driver.forceHomeDatabaseResolution` get called.